### PR TITLE
Added support for sequence values, fixed docs and Py2/3 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,12 +236,15 @@ python setup.py install
 
 + Version: 0.2.0
 + Release date: 2016-09-16
-+ Direct link: https://github.com/watzon/xmler/releases/tag/0.2.0
++ PyPI link: https://pypi.org/project/xmler/
++ Github link: https://github.com/watzon/xmler/releases/tag/0.2.0
 
 # Forked Version
 
 + Version: 0.2.1
 + Release date: 2019-11-02
++ Test PyPI link: https://test.pypi.org/project/xmler/
++ Github link: https://github.com/dimitern/xmler/releases/tag/0.2.1
 + Changes:
 	- Made Python 2 and Python 3 compatible.
 	- Allow sequences as children, updated README.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ myDict = {
 	}
 }
 
-print(dict2xml(myDict, pretty=True, customRoot=None))
+print(dict2xml(myDict, pretty=True))
 ```
 
 Which will return the following XML:
@@ -157,6 +157,50 @@ myDict = {
 }
 ```
 
+#### Sequences within a dictionary
+
+This fork (https://github.com/dimitern/xmler/) additionally supports having
+sequences of type `list`, `set`, or `tuple` (as well as `dict`) as values.
+Non-string values (`int`, `float`, `decimal.Decimal`, and `bool`) are
+converted to strings automatically.
+
+**Example:**
+
+Python input:
+```python
+myDict = {
+	"root": {
+		"child": [
+			{
+				"id": 12,
+			},
+			{
+				"price": Decimal("5.6782")
+			},
+			{
+				"meta": ({"on_stock": True}, {"rating": 3.14})
+			}
+		]
+	}
+}
+```
+
+Pretty XML Output:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <child>
+    <id>12</id>
+    <price>5.6782</price>
+    <meta>
+      <on_stock>True</on_stock>
+      <rating>3.14</rating>
+    </meta>
+  </child>
+</root>
+```
+
+
 # Installation
 
 xmler is [published to PyPi](https://pypi.python.org/pypi/xmler), so installing it is as easy as:
@@ -177,27 +221,34 @@ You can also download the installer as a tar archive and install it using python
 python setup.py install
 ```
 
-# Author
+# Original Author
 
 + Author: Chris Watson
-+ Email: chris@marginzero.co
-+ Repository: http://github.com/iDev0urer/xmler
++ Email: chris@watzon.me
++ Repository: http://github.com/watzon/xmler
 
-# Version
+# Fork Author
++ Author: Dimiter Naydenov
++ Email: dimiter@naydenov.net
++ Repository: http://github.com/dimitern/xmler
 
-+ Version: 0.1.0
-+ Release date: 2016-08-09
+# Original Version
 
-# Revision History
++ Version: 0.2.0
++ Release date: 2016-09-16
++ Direct link: https://github.com/watzon/xmler/releases/tag/0.2.0
 
-## Version 0.1.0
-+ Release date: 2016-08-09
+# Forked Version
+
++ Version: 0.2.1
++ Release date: 2019-11-02
 + Changes:
-	- Initial commit
+	- Made Python 2 and Python 3 compatible.
+	- Allow sequences as children, updated README.
 
-# Copywrite and License
+# Copyright and License
 
-Copywrite 2016 by Christopher Watson
+Copyright 2016 by Christopher Watson
 
 Released under the GNU General Public Licence, Version 2:
 http://www.gnu.org/licenses/old-licenses/gpl-2.0.html

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,24 @@
 from setuptools import setup
 
-version = '0.2.0'
+version = "0.2.1"
 
 setup(
-    name = 'xmler',
-    version = version,
-    description = 'Converts a Python dictionary into a XML string with namespace support.',
-    long_description = "Long description and usage instructions can be found at https://github.com/iDev0urer/xmler",
-    author = 'Chris Watson',
-    author_email = 'chris@marginzero.co',
-    license = 'LICENCE',
-    url = 'https://github.com/iDev0urer/xmler',
-    py_modules = ['xmler'],
-    download_url = 'https://pypi.python.org/packages/source/d/xmler/xmler-%s.tar.gz?raw=true' % (version),
-    platforms='Cross-platform',
+    name="xmler",
+    version=version,
+    description="Converts a Python dictionary into a XML string with namespace support.",
+    long_description="Long description and usage instructions can be found at https://github.com/dimitern/xmler",
+    author="Chris Watson",
+    author_email="chris@marginzero.co",
+    maintainer="Dimiter Naydenov",
+    maintainer_email="dimiter@naydenov.net",
+    license="LICENCE",
+    url="https://github.com/dimitern/xmler",
+    py_modules=["xmler"],
+    download_url="https://pypi.python.org/packages/source/d/xmler/xmler-%s.tar.gz?raw=true"
+    % (version),
+    platforms="Cross-platform",
     classifiers=[
-      'Programming Language :: Python',
-      'Programming Language :: Python :: 3'
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2" "Programming Language :: Python :: 3",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     platforms="Cross-platform",
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2" "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license="LICENCE",
     url="https://github.com/dimitern/xmler",
     py_modules=["xmler"],
-    download_url="https://pypi.python.org/packages/source/d/xmler/xmler-%s.tar.gz?raw=true"
+    download_url="https://test.pypi.python.org/packages/source/d/xmler/xmler-%s.tar.gz?raw=true"
     % (version),
     platforms="Cross-platform",
     classifiers=[

--- a/xmler.py
+++ b/xmler.py
@@ -7,22 +7,47 @@ Converts a Python dictionary to a valid XML string
 
 from __future__ import unicode_literals
 
-__version__ = '0.2.0'
-version = __version__
-
+import sys
+from decimal import Decimal
 from xml.dom import minidom
 from xml.etree.ElementTree import Element, tostring
 
-import logging
+__version__ = "0.2.1"
+version = __version__
 
-def dict2xml(dict, encoding="utf-8", pretty=False):
+
+def to_text(value):
+    return unicode(value) if sys.version_info.major < 3 else str(value)
+
+
+def to_bytes(value):
+    return str(value) if sys.version_info.major < 3 else bytes(value)
+
+
+def is_text(value):
+    return (
+        isinstance(value, unicode)
+        if sys.version_info.major < 3
+        else isinstance(value, str)
+    )
+
+
+def iteritems(dict_obj):
+    return dict_obj.iteritems() if sys.version_info.major < 3 else dict_obj.items()
+
+
+def dict2xml(dict_obj, encoding="utf-8", pretty=False):
     """Converts a python dictionary into a valid XML string
 
     Args:
-        - encoding specifies the encoding to be included in the encoding
+        - `dict_obj` is the dict-like object to convert. It can contain
+          other dictionaries, with string keys and values convertable to
+          strings, as well as list, sets, and tuples of such dictionaries.
+        - `encoding` specifies the encoding to be included in the encoding
           segment. If set to False no encoding segment will be displayed.
-        - customRoot defines the tag to wrap the returned output. Can be
-          a string, dictionary, or False if no custom root is to be used.
+        - `pretty` (False by default) can be True if you want to get a
+          "prettified" result as a string, which also ensures the result
+          is well-formed XML.
 
     Returns:
         A XML formatted string representing the dictionary.
@@ -59,68 +84,83 @@ def dict2xml(dict, encoding="utf-8", pretty=False):
             }
         }
 
-        xml = xml2dict(dict, customRoot=False)
+        xml = dict2xml(dic, pretty=True)
         print(xml)
         ```
 
         output:
         ```
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="utf-8"?>
         <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
           xmlns:urn="urn:partner.soap.sforce.com">
           <soapenv:Header>
-             <urn:SessionHeader>
-                <urn:sessionId>{0}</urn:sessionId>
-             </urn:SessionHeader>
+            <urn:SessionHeader>
+              <urn:sessionId>00D36000000b28L!ARsAQMtHo4XD71VYRxoz</urn:sessionId>
+            </urn:SessionHeader>
           </soapenv:Header>
+          <soapenv:Body>
+            <urn:query>
+              <urn:queryString>SELECT Id, Name FROM Account LIMIT 2</urn:queryString>
+            </urn:query>
+          </soapenv:Body>
         </soapenv:Envelope>
         ```
     """
 
-    xml_string = tostring(parse(dict, pretty=pretty), encoding=encoding)
+    xml_string = to_bytes(tostring(parse(dict_obj, pretty=pretty), encoding=encoding))
 
     if pretty:
-        xml_pretty_string = minidom.parseString(xml_string)
-        return xml_pretty_string.toprettyxml().decode(encoding)
+        xml_pretty_string = minidom.parseString(xml_string.decode(encoding))
+        return xml_pretty_string.toprettyxml(encoding=encoding, indent="  ").decode(
+            encoding
+        )
     else:
-        return xml_string.decode(encoding)
+        return to_text(xml_string.decode(encoding))
 
 
-def parse(dict, parent={}, pretty=False):
+def parse(dict_obj, parent={}, pretty=False):
 
-    for key, value in dict.items():
+    for key, value in iteritems(dict_obj):
 
-        if '@ns' in value:
-            parent['namespace'] = value['@ns']
-            value.pop('@ns')
+        if isinstance(value, (int, float, Decimal, bool)):
+            value = to_text(value)
 
-        if '@attrs' in value:
-            parent['attributes'] = value['@attrs']
-            value.pop('@attrs')
+        if "@ns" in value:
+            parent["namespace"] = value["@ns"]
+            value.pop("@ns")
 
-        if '@name' in value:
-            parent['name'] = value['@name']
-            value.pop('@name')
+        if "@attrs" in value:
+            parent["attributes"] = value["@attrs"]
+            value.pop("@attrs")
+
+        if "@name" in value:
+            parent["name"] = value["@name"]
+            value.pop("@name")
         else:
-            parent['name'] = key
+            parent["name"] = key
 
-        if '@value' in value:
-            parent['value'] = value = value['@value']
+        if "@value" in value:
+            parent["value"] = value = value["@value"]
         else:
-            parent['value'] = value
+            parent["value"] = value
 
-    if 'namespace' in parent:
-        parent['name'] = "%s:%s" % (parent['namespace'], parent['name'])
+    if "namespace" in parent:
+        parent["name"] = "%s:%s" % (parent["namespace"], parent["name"])
 
-    if 'attributes' in parent:
-        element = Element(parent['name'], parent['attributes'])
+    if "attributes" in parent:
+        element = Element(parent["name"], parent["attributes"])
     else:
-        element = Element(parent['name'])
+        element = Element(parent["name"])
 
-    if isinstance(parent['value'], str):
-        element.text = parent['value']
-    else:
-        for child_key, child_value in value.items():
+    if isinstance(parent["value"], dict):
+        for child_key, child_value in iteritems(parent["value"]):
             element.append(parse({child_key: child_value}, parent={}))
+
+    elif isinstance(parent["value"], (list, set, tuple)):
+        for child in parent["value"]:
+            element.append(parse(child, parent={}))
+
+    else:
+        element.text = to_text(parent["value"])
 
     return element


### PR DESCRIPTION
Hey @watzon, and thank you for the awesome project!

It was just what I needed for my project, but the lack of support for lists of dicts is a major obstacle, as I need to convert stuff like `{"a": {"b": [{"c":1},{"c":2},{"d":"foo"}]}}`. So I made and tested those additions locally, and also updated the docstrings and README where it was outdated.

I'd be happy to adapt this PR as you see fit, should you decide to merge some or more of it.

Cheers!